### PR TITLE
feat: add from_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,5 @@ postgres-from-row-derive = { path = "postgres-from-row-derive", version = "=0.5.
 tokio-postgres = { version = "0.7.8", default_features = false }
 postgres-from-row-derive.workspace = true
 
+[dev-dependencies]
+tokio-postgres = { version = "0.7.8", default_features = false, features = ["with-serde_json-1"] }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use postgres_from_row::FromRow;
-use tokio_postgres::Row;
+use tokio_postgres::{types::Json, Row};
 
 #[derive(FromRow)]
 #[allow(dead_code)]
@@ -8,6 +10,12 @@ pub struct Todo {
     text: String,
     #[from_row(flatten)]
     user: User,
+    #[from_row(from_fn = "json")]
+    json: HashMap<String, bool>,
+}
+
+fn json<T>(wrapper: Json<T>) -> T {
+    wrapper.0
 }
 
 #[derive(FromRow)]


### PR DESCRIPTION
`from_fn` allows generics and extends the ability of the default `from` attribute, it also allows for foreign types to be converted, if they dont implement the correct traits.

```rs
pub struct Example {
    #[from_row(from_fn = "json")]
    json: HashMap<String, bool>,
}

fn json<T>(wrapper: Json<T>) -> T {
    wrapper.0
}
```